### PR TITLE
Rewrite the configuration file handling

### DIFF
--- a/reviewcheck/app.py
+++ b/reviewcheck/app.py
@@ -16,7 +16,6 @@ import time
 from concurrent.futures import ThreadPoolExecutor
 
 import requests
-import yaml
 from rich import box
 from rich.console import Console
 from rich.panel import Panel
@@ -27,6 +26,7 @@ from rich.text import Text
 from reviewcheck.cli import Cli
 from reviewcheck.common.constants import Constants
 from reviewcheck.common.url_builder import UrlBuilder
+from reviewcheck.config import Config
 
 console = Console()
 THREAD_POOL = 16
@@ -119,8 +119,7 @@ def get_rows_highlighting(comment, needs_reply, uname):
 
 def run() -> int:
     args = Cli.parse_arguments()
-    with open(Constants.CONFIG_PATH, "r") as f:
-        config = yaml.safe_load(f)
+    config = Config(args.command == "configure").get_configuration()
 
     secret_token = config["secret_token"]
     api_url = config["api_url"]

--- a/reviewcheck/cli.py
+++ b/reviewcheck/cli.py
@@ -65,4 +65,13 @@ class Cli:
             default=[],
             dest="ignore",
         )
+
+        subparsers = parser.add_subparsers(dest="command")
+
+        subparsers.add_parser(
+            "configure",
+            help="Interactively set up configuration file",
+            description="Asks for input to write to the configuration file.",
+        )
+
         return parser.parse_args()

--- a/reviewcheck/config.py
+++ b/reviewcheck/config.py
@@ -1,0 +1,50 @@
+import yaml
+
+from reviewcheck.common.constants import Constants
+
+
+class Config:
+    """
+    Class for interacting with the configuration file.
+    """
+
+    def __init__(self, reconfigure: bool):
+        self.reconfigure = reconfigure
+
+    def get_configuration(self) -> dict:
+        """
+        Reads the configuration file into a dictionary. If the configuration file does
+        not exist, queries the user for information and writes it.
+
+        :param reconfigure: If True, forces reconfiguration.
+
+        :return: A dict containing the contents of the configuration file.
+        """
+
+        # Only attempt to write the configuration file if it does not already exist
+        if self.reconfigure or not Constants.CONFIG_PATH.exists():
+            Constants.CONFIG_PATH.parent.mkdir(parents=True, exist_ok=True)
+
+            if not self.reconfigure:
+                print(
+                    f"No configuration file found at {str(Constants.CONFIG_PATH)}, "
+                    "please provide some information to populate it:"
+                )
+
+            token = input("GitLab API token: ")
+            username = input("Username: ")
+            api_url = input("API URL: ")
+            jira_url = input("Jira URL: ")
+
+            config_object = {
+                "secret_token": token,
+                "user": username,
+                "api_url": api_url,
+                "jira_url": jira_url,
+            }
+
+            with open(Constants.CONFIG_PATH, "w") as f:
+                f.write(yaml.safe_dump(config_object))
+
+        with open(Constants.CONFIG_PATH, "r") as f:
+            return yaml.safe_load(f)


### PR DESCRIPTION
The configuration file handling has been made more robust, by querying
the user for credentials if it does not exist. The new "configure" verb
allows for (re-)configuring.
