### PR TITLE
Read project IDs from config file

### DIFF
--- a/reviewcheck/app.py
+++ b/reviewcheck/app.py
@@ -117,9 +117,35 @@ def get_rows_highlighting(comment, needs_reply, uname):
     )
 
 
+def configure() -> int:
+    Config(True).setup_configuration()
+    return 0
+
+
 def run() -> int:
     args = Cli.parse_arguments()
-    config = Config(args.command == "configure").get_configuration()
+
+    command_palette = {
+        "configure": configure,
+    }
+
+    if args.command:
+        func = command_palette.get(args.command)
+
+        if func is not None:
+            return func()
+        else:
+            print(
+                f"'{args.command} is not a valid command, please see "
+                "`reviewcheck --help`."
+            )
+            return 127
+
+    config = Config(False).get_configuration()
+
+    if config is None:
+        print(f"Could not read configuration from {str(Constants.CONFIG_PATH)}.")
+        return 1
 
     secret_token = config["secret_token"]
     api_url = config["api_url"]

--- a/reviewcheck/config.py
+++ b/reviewcheck/config.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 import yaml
 
 from reviewcheck.common.constants import Constants
@@ -11,16 +13,7 @@ class Config:
     def __init__(self, reconfigure: bool):
         self.reconfigure = reconfigure
 
-    def get_configuration(self) -> dict:
-        """
-        Reads the configuration file into a dictionary. If the configuration file does
-        not exist, queries the user for information and writes it.
-
-        :param reconfigure: If True, forces reconfiguration.
-
-        :return: A dict containing the contents of the configuration file.
-        """
-
+    def setup_configuration(self) -> None:
         # Only attempt to write the configuration file if it does not already exist
         if self.reconfigure or not Constants.CONFIG_PATH.exists():
             Constants.CONFIG_PATH.parent.mkdir(parents=True, exist_ok=True)
@@ -51,5 +44,18 @@ class Config:
             with open(Constants.CONFIG_PATH, "w") as f:
                 f.write(yaml.safe_dump(config_object))
 
-        with open(Constants.CONFIG_PATH, "r") as f:
-            return yaml.safe_load(f)
+    def get_configuration(self) -> Optional[dict]:
+        """
+        Reads the configuration file into a dictionary. If the configuration file does
+        not exist, queries the user for information and writes it.
+
+        :return: A dict containing the contents of the configuration file, or None if
+        the file does not exist.
+        """
+
+        self.setup_configuration()
+        try:
+            with open(Constants.CONFIG_PATH, "r") as f:
+                return yaml.safe_load(f)
+        except FileNotFoundError:
+            return None


### PR DESCRIPTION
- Store project IDs in config file
- Fix program running after `configure`
