### PR TITLE
Introduce version flag

### DIFF
--- a/reviewcheck/app.py
+++ b/reviewcheck/app.py
@@ -170,6 +170,12 @@ def get_info_box_content(
 def run() -> int:
     args = Cli.parse_arguments()
 
+    if args.print_version:
+        from reviewcheck import __version__
+
+        print(__version__)
+        return 0
+
     command_palette = {
         "configure": configure,
     }

--- a/reviewcheck/cli.py
+++ b/reviewcheck/cli.py
@@ -39,6 +39,15 @@ class Cli:
             formatter_class=RawTextHelpFormatter,
         )
 
+        parser.add_argument(
+            "--version",
+            help="Show version",
+            dest="print_version",
+            required=False,
+            action="store_true",
+            default=False,
+        )
+
         shtab.add_argument_to(parser, ["-s", "--print-completion"])
 
         parser.add_argument(


### PR DESCRIPTION
It seems we had forgotten to add a `--version` flag. This PR introduces the flag, which works exactly as you'd expect.
