### PR TITLE
Fix bug where app crashes on empty MR

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+
+- Bug where the presence of an MR with no discussions on it would cause
+  the app to crash.
+
 ## [0.2.0] - 2022-06-02
 
 ### Added

--- a/reviewcheck/app.py
+++ b/reviewcheck/app.py
@@ -75,7 +75,7 @@ def download_gitlab_data(
             time.sleep(5)
 
     if isinstance(response_json, list):
-        if isinstance(response_json[0], dict):
+        if len(response_json) == 0 or isinstance(response_json[0], dict):
             return response_json, mr_id
 
     raise Exception("Malformed data returned from GitLab.")


### PR DESCRIPTION
There was a bug where the app would crash if there were no discussions
on an MR. This is fixed now.
