### PR TITLE
Add flag for showing minimal output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ All notable changes to this project will be documented in this file.
 - Interactive configuration of tool.
 - Tab completion file generation.
 - Source branch name is now shown in the info box for each MR.
+- Flag for hiding discussions you don't need to reply to (`--minimal`).
+  That is, if you are the last person to have written in a discussion
+  in an MR that you are a part of, that discussion will be hidden rather
+  than just greyed out.
 
 ### Changed
 

--- a/reviewcheck/app.py
+++ b/reviewcheck/app.py
@@ -324,6 +324,12 @@ def run() -> int:
                 console.print(mr_info_header)
 
             for comment in discussion_data:
+                # When minimal view is requsted, only show threads where a response is
+                # required
+                if args.minimal:
+                    if comment["notes"][-1]["author"]["username"] == user:
+                        continue
+
                 reply_needed = False
                 if comment["notes"][-1]["author"]["username"] != user:
                     reply_needed = True

--- a/reviewcheck/cli.py
+++ b/reviewcheck/cli.py
@@ -97,6 +97,15 @@ class Cli:
             dest="refresh_time",
         )
 
+        parser.add_argument(
+            "-m",
+            "--minimal",
+            help="Only show discussion where a reply is needed.",
+            action="store_true",
+            default=False,
+            dest="minimal",
+        )
+
         subparsers = parser.add_subparsers(dest="command")
 
         subparsers.add_parser(


### PR DESCRIPTION
By default, if there is anything to reply to in an MR, all discussions
for that MR are shown, albeit with the ones you don't need to reply to
(that you were the last person to respond to)
greyed out. With the --minimal flag, only the discussions you actually
need to reply to are shown. This is useful if there are a lot of
discussions on an MR.

Closes #44