### PR TITLE
Fix poetry command not available in deploy stage

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -44,8 +44,9 @@ jobs:
           name: reviewcheck-package
 
       - run: |
+          version="$(find -name 'reviewcheck-*.tar.gz' | sort -rn | head -1 | sed 's|\./foo-\(.*\)\.tar\.gz|\1|')"
           curl -sSf -H "X-JFrog-Art-Api:$ARTIFACTORY_TOKEN" -X PUT \
-          -T reviewcheck-*.tar.gz "$ARTIFACTORY_BASE_URL/$(poetry version -s)/"
+          -T reviewcheck-*.tar.gz "$ARTIFACTORY_BASE_URL/$version/"
         env:
           ARTIFACTORY_TOKEN: ${{ secrets.ARTIFACTORY_TOKEN }}
           ARTIFACTORY_BASE_URL: ${{ secrets.ARTIFACTORY_BASE_URL }}


### PR DESCRIPTION
Because we didn't set up Python and Poetry in the actual deploy stage of
the deploy workflow, the version(s) posted didn't end up in the correct
place. Fix this by extracting the version number from the actual
reviewcheck artifact.
