### PR TITLE
fix retry errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,18 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+
+- Flag for hiding discussions you don't need to reply to (`--minimal`).
+  That is, if you are the last person to have written in a discussion
+  in an MR that you are a part of, that discussion will be hidden rather
+  than just greyed out.
+
 ### Fixed
 
 - Bug where the presence of an MR with no discussions on it would cause
   the app to crash.
+- Session is now reset for each time we get new data from GitLab.
 
 ## [0.2.0] - 2022-06-02
 
@@ -16,10 +24,6 @@ All notable changes to this project will be documented in this file.
 - Interactive configuration of tool.
 - Tab completion file generation.
 - Source branch name is now shown in the info box for each MR.
-- Flag for hiding discussions you don't need to reply to (`--minimal`).
-  That is, if you are the last person to have written in a discussion
-  in an MR that you are a part of, that discussion will be hidden rather
-  than just greyed out.
 
 ### Changed
 

--- a/reviewcheck/app.py
+++ b/reviewcheck/app.py
@@ -24,43 +24,23 @@ from reviewcheck.common.url_builder import UrlBuilder
 from reviewcheck.config import Config
 
 console = Console()
-THREAD_POOL = 16
-
-# This is how to create a reusable connection pool with python requests.
-session = requests.Session()
-session.mount(
-    "https://",
-    requests.adapters.HTTPAdapter(
-        pool_maxsize=THREAD_POOL, max_retries=3, pool_block=True
-    ),
-)
+THREAD_POOL = 32
 
 
 def download_gitlab_data(
     get_data: Tuple[str, int, str],
 ) -> Tuple[List[Dict[str, Any]], int]:
-    url, mr_id, secret_token = get_data
-    response = session.get(url, headers={"PRIVATE-TOKEN": secret_token})
-    response_json = json.loads(response.content)
-    logging.info(
-        "request was completed in %s seconds [%s]",
-        response.elapsed.total_seconds(),
-        response.url,
-    )
-    if response.status_code != 200:
-        logging.error(
-            "request failed, error code %s [%s]", response.status_code, response.url
+    # This is how to create a reusable connection pool with python requests.
+    with requests.Session() as session:
+        session.mount(
+            "https://",
+            requests.adapters.HTTPAdapter(
+                pool_maxsize=THREAD_POOL, max_retries=3, pool_block=True
+            ),
         )
-    if 500 <= response.status_code < 600:
-        # server is overloaded? give it a break
-        time.sleep(5)
-
-    num_pages = int(response.headers["X-Total-Pages"])
-    for page in range(2, num_pages + 1):
-        response = session.get(
-            f"{url}&page={page}", headers={"PRIVATE-TOKEN": secret_token}
-        )
-        response_json += json.loads(response.content)
+        url, mr_id, secret_token = get_data
+        response = session.get(url, headers={"PRIVATE-TOKEN": secret_token})
+        response_json = json.loads(response.content)
         logging.info(
             "request was completed in %s seconds [%s]",
             response.elapsed.total_seconds(),
@@ -73,6 +53,27 @@ def download_gitlab_data(
         if 500 <= response.status_code < 600:
             # server is overloaded? give it a break
             time.sleep(5)
+
+        num_pages = int(response.headers["X-Total-Pages"])
+        for page in range(2, num_pages + 1):
+            response = session.get(
+                f"{url}&page={page}", headers={"PRIVATE-TOKEN": secret_token}
+            )
+            response_json += json.loads(response.content)
+            logging.info(
+                "request was completed in %s seconds [%s]",
+                response.elapsed.total_seconds(),
+                response.url,
+            )
+            if response.status_code != 200:
+                logging.error(
+                    "request failed, error code %s [%s]",
+                    response.status_code,
+                    response.url,
+                )
+            if 500 <= response.status_code < 600:
+                # server is overloaded? give it a break
+                time.sleep(5)
 
     if isinstance(response_json, list):
         if len(response_json) == 0 or isinstance(response_json[0], dict):


### PR DESCRIPTION
There was an issue with errors showing up on the second run when the -r
flag was specified. This PR solves that by starting a new session each
time new data is fetched.
