### PR TITLE
Fix deploy package name

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -44,7 +44,7 @@ jobs:
           name: reviewcheck-package
 
       - run: |
-          version="$(find -name 'reviewcheck-*.tar.gz' | sort -rn | head -1 | sed 's|\./foo-\(.*\)\.tar\.gz|\1|')"
+          version="$(find -name 'reviewcheck-*.tar.gz' | sort -rn | head -1 | sed 's|\./reviewcheck-\(.*\)\.tar\.gz|\1|')"
           curl -sSf -H "X-JFrog-Art-Api:$ARTIFACTORY_TOKEN" -X PUT \
           -T reviewcheck-*.tar.gz "$ARTIFACTORY_BASE_URL/$version/"
         env:


### PR DESCRIPTION
In the previous "fix" of the deploy stage, somehow a debug version snuck
into main. Instead of searching for packages on the format
"reviewcheck-X.Y.Z.tar.gz", it would search for "foo-X.Y.Z.tar.gz". A
little embarrassing, but it has now been fixed.
