### PR TITLE
Handle terminal output widths more dynamically

### DIFF
--- a/reviewcheck/app.py
+++ b/reviewcheck/app.py
@@ -9,6 +9,7 @@ import re
 import time
 from concurrent.futures import ThreadPoolExecutor
 from datetime import datetime
+from shutil import get_terminal_size
 from typing import Any, Dict, List, Optional, Tuple
 
 import requests
@@ -240,7 +241,7 @@ def show_reviews(config: Dict[str, Any]) -> None:
             ),
             style="reverse bold",
         ),
-        width=Constants.TUI_MAX_WIDTH,
+        width=config["output_width"],
     )
 
     for id, mr in mrs.items():
@@ -295,7 +296,7 @@ def show_reviews(config: Dict[str, Any]) -> None:
                     )
                 ),
                 title=get_info_box_title(mr, jira, color),
-                width=Constants.TUI_MAX_WIDTH,
+                width=config["output_width"],
             )
             console.print(mr_info_header)
 
@@ -324,7 +325,7 @@ def show_reviews(config: Dict[str, Any]) -> None:
                 row_styles=row_highlighting_style,
                 border_style=border_color,
                 header_style=f"bold {color}",
-                width=Constants.TUI_MAX_WIDTH,
+                width=config["output_width"],
                 box=box.ROUNDED,
             )
 
@@ -333,7 +334,7 @@ def show_reviews(config: Dict[str, Any]) -> None:
             threads_table.add_column(
                 "Message",
                 style="dim",
-                min_width=Constants.TUI_MAX_WIDTH
+                min_width=config["output_width"]
                 - Constants.TUI_AUTHOR_WIDTH
                 - Constants.TUI_DATE_WIDTH
                 - Constants.TUI_THREE_COL_PADDING_WIDTH,
@@ -389,6 +390,11 @@ def run() -> int:
 
     if args.user:
         config["user"] = args.user.upper()
+
+    if args.output_width:
+        config["output_width"] = args.output_width
+    else:
+        config.setdefault("output_width", get_terminal_size().columns)
 
     if "ignored_mrs" not in config:
         config["ignored_mrs"] = args.ignore

--- a/reviewcheck/cli.py
+++ b/reviewcheck/cli.py
@@ -105,6 +105,15 @@ class Cli:
             dest="minimal",
         )
 
+        parser.add_argument(
+            "-w",
+            "--width",
+            help="Terminal display width",
+            type=Cli.check_positive_int,
+            action="store",
+            dest="output_width",
+        )
+
         subparsers = parser.add_subparsers(dest="command")
 
         subparsers.add_parser(

--- a/reviewcheck/common/constants.py
+++ b/reviewcheck/common/constants.py
@@ -35,7 +35,6 @@ class Constants:
 
     CONFIG_PATH: Path = Path.home() / ".config" / "reviewcheckrc"
 
-    TUI_MAX_WIDTH = 108
     TUI_AUTHOR_WIDTH = 16
     TUI_DATE_WIDTH = 12
     TUI_TWO_COL_PADDING_WIDTH = 7


### PR DESCRIPTION
Currently, reviewcheck is made to be 108 characters wide. This leaves some screen estate unused in some edge cases (why wouldn't you use a monitor in portrait mode with reviewcheck? :)).  With this proposed change, we now have three ways to configure width (in order of precedence):

 * Command line flag `--width` (e.g. `--width 108`)
 * Configured setting (the optional `output_width` settings key in `reviewcheckrc`)
 * The `$COLUMNS` env variable, usually automatically set by your shell. This will make reviewcheck fill up the whole terminal in width.

If a width isn't specified in any of these ways, we default to 80.