### PR TITLE
Make sure the username is always in uppercase

### DIFF
--- a/reviewcheck/app.py
+++ b/reviewcheck/app.py
@@ -428,7 +428,8 @@ def run() -> int:
         return 1
 
     if args.user:
-        config["user"] = args.user.upper()
+        config["user"] = args.user
+    config["user"] = config["user"].upper()
 
     if args.output_width:
         config["output_width"] = args.output_width


### PR DESCRIPTION
The configured username needs to be in uppercase for it to be found in GitLab discussions. It is now ensured to be.

Closes #68 