### PR TITLE
Add link to source code for MPL-2 packages

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -22,7 +22,7 @@ mccabe 0.6.1 : MIT License
 mypy 0.961 : MIT License
 mypy-extensions 0.4.3 : MIT License
 Packaging 21.3 : (BSD 2-clause "Simplified" License OR Apache License 2.0)
-pathspec 0.9.0 : Mozilla Public License 2.0
+pathspec 0.9.0 (https://github.com/cpburnz/python-pathspec) : Mozilla Public License 2.0
 platformdirs 2.4.0 : MIT License
 py 1.11.0 : MIT License
 pycodestyle 2.8.0 : Expat License
@@ -31,7 +31,7 @@ Pygments - Python syntax highlighter 2.12.0 : BSD 3-clause "New" or "Revised" Li
 Pyparsing 3.0.9 : MIT License
 pytest 7.0.1 : MIT License
 python-attrs 21.4.0 : MIT License
-python-certifi 2022.6.15 : Mozilla Public License 2.0
+python-certifi 2022.6.15 (https://github.com/certifi/python-certifi) : Mozilla Public License 2.0
 python-pluggy 1.0.0 : MIT License
 python-typing-extensions 4.1.1 : Python Software Foundation License 2.3
 PyYAML 5.4.1 : MIT License


### PR DESCRIPTION
Packages licensed under MPL-2 require a reference to their source code from our NOTICE file. This has been added.

