### PR TITLE
Use Python 3.8 in CI

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -22,7 +22,7 @@ jobs:
 
       - uses: actions/setup-python@v3
         with:
-          python-version: "3.6"
+          python-version: "3.8"
           cache: "poetry"
 
       - name: Install dependencies
@@ -47,7 +47,7 @@ jobs:
 
       - uses: actions/setup-python@v3
         with:
-          python-version: "3.6"
+          python-version: "3.8"
           cache: "poetry"
 
       - name: Install dependencies
@@ -66,7 +66,7 @@ jobs:
 
       - uses: actions/setup-python@v3
         with:
-          python-version: "3.6"
+          python-version: "3.8"
           cache: "poetry"
 
       - name: Install dependencies

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -46,7 +46,7 @@ jobs:
 
       - uses: actions/setup-python@v3
         with:
-          python-version: "3.6"
+          python-version: "3.8"
           cache: "poetry"
 
       - name: Install dependencies


### PR DESCRIPTION
We were using Python 3.6 in the CI, but this has reached end of life and is no longer suitable as a main testing environment. We now use a Python 3.8 image for the CI.
