### PR TITLE
Introduce --no-notifcations and a Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,9 @@
+FROM python:alpine
+
+WORKDIR /root/
+
+COPY . .
+
+RUN pip --no-python-version-warning --disable-pip-version-check install --root-user-action=ignore .
+
+ENTRYPOINT ["reviewcheck", "--no-notifications"]

--- a/README.md
+++ b/README.md
@@ -11,22 +11,36 @@ Reviewcheck is in active development.
 
 ## Installation
 
+### With pip
+
 Reviewcheck can be installed with the following command:
 
-```Shell
-pip install reviewcheck
+```console
+$ pip install reviewcheck
 ```
+
+### With Poetry
 
 If you are a developer, the best way to test changes you make without having to
 create a Python package and install it is to clone the repository and run
 `poetry run reviewcheck` from within it. You will need to have poetry
 installed. The process looks as follows:
 
-```Shell
-pip install poetry
-git clone https://github.com/volvo-cars/Reviewcheck
-cd reviewcheck
-poetry run reviewcheck
+```console
+$ pip install poetry
+$ git clone https://github.com/volvo-cars/Reviewcheck
+$ cd reviewcheck
+$ poetry run reviewcheck
+```
+
+### With Docker
+
+There's also a Dockerfile available to use. Currently it does not get uploaded
+anywhere, so you'll need to build it locally and then run it. Example commands:
+
+```console
+$ docker build -t reviewcheck .
+$ docker run -tv ~/.config/reviewcheckrc:/root/.config/reviewcheckrc reviewcheck
 ```
 
 ## Getting Started

--- a/reviewcheck/app.py
+++ b/reviewcheck/app.py
@@ -226,7 +226,7 @@ def write_comment_note_ids_to_file(new_comment_note_ids: Set[str]) -> None:
             f.write(f"{id}\n")
 
 
-def show_reviews(config: Dict[str, Any]) -> None:
+def show_reviews(config: Dict[str, Any], no_notifications: bool) -> None:
     """Download MR data and present review info for each relevant MR.
 
     :param config: The resolved configuration of reviewcheck.
@@ -373,7 +373,10 @@ def show_reviews(config: Dict[str, Any]) -> None:
                 # For notifications
                 new_comment_note_id = comment["notes"][-1]["id"]
                 new_comment_note_ids.add(new_comment_note_id)
-                if str(new_comment_note_id) not in old_comment_note_ids:
+                if (
+                    not no_notifications
+                    and str(new_comment_note_id) not in old_comment_note_ids
+                ):
                     title = f'{comment["notes"][-1]["author"]["name"]} via Reviewcheck'
                     body = comment["notes"][-1]["body"]
                     subprocess.run(["notify-send", "--expire-time=15000", title, body])
@@ -479,12 +482,12 @@ def run() -> int:
 
     try:
         if args.refresh_time is None:
-            show_reviews(config)
+            show_reviews(config, args.no_notifications)
             return 0
 
         while True:
             console.clear()
-            show_reviews(config)
+            show_reviews(config, args.no_notifications)
             time.sleep(args.refresh_time * 60)
     except KeyboardInterrupt:
         print("\nBye bye!")

--- a/reviewcheck/cli.py
+++ b/reviewcheck/cli.py
@@ -139,6 +139,14 @@ class Cli:
             dest="output_width",
         )
 
+        parser.add_argument(
+            "-N",
+            "--no-notifications",
+            help="Do not invoke notify-send(1)",
+            action="store_true",
+            default=False,
+        )
+
         subparsers = parser.add_subparsers(dest="command")
 
         subparsers.add_parser(


### PR DESCRIPTION
With --no-notifications, we do not invoke notify-send(1) at all.

Simple Dockerfile for running reviewcheck.

This PR contains two commits that should be treated as two separate features, but are grouped into the same PR because the Dockerfile depends on --no-notifications being available.